### PR TITLE
[urlutil] Align fuzz test path cleaning

### DIFF
--- a/internal/urlutil/urls_fuzz_test.go
+++ b/internal/urlutil/urls_fuzz_test.go
@@ -405,8 +405,8 @@ func FuzzBuildGitHubFileURL(f *testing.F) {
 			assert.Contains(t, result, sanitizedBranch, "Should contain sanitized branch")
 			assert.Contains(t, result, "/blob/", "Should contain blob path")
 
-			// The file path should be processed through CleanModulePath
-			cleanedPath := CleanModulePath(filePath)
+			// The file path should be processed through CleanModulePathWithRepo
+			cleanedPath := CleanModulePathWithRepo(filePath, sanitizedRepo)
 			assert.Contains(t, result, cleanedPath, "Should contain cleaned file path")
 		}
 


### PR DESCRIPTION
## What Changed
- Align fuzz test path verification with repository-aware path cleaner

## Why It Was Necessary
- Fuzz test used `CleanModulePath`, which disagreed with `BuildGitHubFileURL`'s `CleanModulePathWithRepo`, causing false failures

## Testing Performed
- `go test ./internal/urlutil`
- `go test ./...` *(fails: TestErrorHandlingEdgeCases/Save record to read-only directory)*

## Impact / Risk
- Low; updates tests only

Assignees: @mrz1836

------
https://chatgpt.com/codex/tasks/task_e_68b1ac1607d48321bf7583b64e4f8a5d