### PR TITLE
[History] Remove global benchmark counter

### DIFF
--- a/internal/history/tracker_bench_test.go
+++ b/internal/history/tracker_bench_test.go
@@ -12,8 +12,6 @@ import (
 	"github.com/mrz1836/go-coverage/internal/parser"
 )
 
-var benchCounter int64
-
 // BenchmarkRecord benchmarks recording coverage entries
 func BenchmarkRecord(b *testing.B) {
 	tempDir, err := os.MkdirTemp("", "history_bench_*")
@@ -402,6 +400,7 @@ func BenchmarkConcurrentRecord(b *testing.B) {
 	config := &Config{StoragePath: tempDir}
 	tracker := NewWithConfig(config)
 	ctx := context.Background()
+	var benchCounter int64
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			coverage := createBenchmarkCoverage()


### PR DESCRIPTION
## What Changed
- Move benchmark counter into `BenchmarkConcurrentRecord` to avoid global state

## Why It Was Necessary
- `golangci-lint` flagged a global variable in tests (`gochecknoglobals`)

## Testing Performed
- `go test ./...` *(fails: TestErrorHandlingEdgeCases/Save_record_to_read-only_directory expected error but got nil)*
- `golangci-lint run ./...` *(fails: unknown linters `arangolint`, `embeddedstructfieldcheck`, `wsl_v5`)*

## Impact / Risk
- No functional impact; change is limited to benchmarks
- Low risk of regression

Assignees: @mrz1836

------
https://chatgpt.com/codex/tasks/task_e_68b1ac31a89883218f764b9830417a9a